### PR TITLE
bump VM memory limit from 3GB to 6GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,14 @@ Vagrant.configure('2') do |config|
 
   config.vm.provider :virtualbox do |v, override|
     override.omnibus.chef_version = "10.26.0"
-    v.customize ["modifyvm", :id, "--memory", 3*1024]
+    v.customize ["modifyvm", :id, "--memory", 6*1024]
     v.customize ["modifyvm", :id, "--cpus", 4]
   end
 
   config.vm.provider :vmware_fusion do |v, override|
     override.vm.box_url = 'http://files.vagrantup.com/precise64_vmware.box'
     v.vmx["numvcpus"] = "4"
-    v.vmx["memsize"] = 3 * 1024
+    v.vmx["memsize"] = 6 * 1024
   end
 
   config.vm.network :private_network, ip: '192.168.50.4'


### PR DESCRIPTION
We've found 3GB to be a bit too low for our development workflow.
