### PR TITLE
Set shell to bash for user 'vagrant' and fix README

### DIFF
--- a/boxes/README.md
+++ b/boxes/README.md
@@ -14,8 +14,9 @@ To build all boxes:
 Or, to build one box:
 
     make list
-    # Choose a definition, like 'virtualbox/boshlite-ubuntu1204'
-    make virtualbox/boshlite-ubuntu1204
+
+    # Choose a definition, like 'virtualbox/boshlite-ubuntu1204.box'
+    make virtualbox/boshlite-ubuntu1204.box
 ##Launch bosh-lite boxes
 
 Use the Vagrantfile in this folder

--- a/boxes/template/boshlite-ubuntu1204/script/vagrant.sh
+++ b/boxes/template/boshlite-ubuntu1204/script/vagrant.sh
@@ -4,7 +4,7 @@ date > /etc/vagrant_box_build_time
 
 # Vagrant user
 /usr/sbin/groupadd vagrant
-/usr/sbin/useradd vagrant -g vagrant -G sudo -d /home/vagrant --create-home
+/usr/sbin/useradd vagrant -g vagrant -G sudo -d /home/vagrant --create-home --shell /bin/bash
 echo "vagrant:vagrant" | chpasswd
 
 # Set up sudo.  Be careful to set permission BEFORE copying file to sudoers.d


### PR DESCRIPTION
When using the packer constructed bosh-lite base box, the default shell for the 'vagrant' user was /bin/sh instead of /bin/bash.  That's inconsistent with the public vagrant boxes and is very unfriendly to the user.

Also, the readme in the makefile was missing the .box suffices on the targets.
