### PR TITLE
vagrant up failing: nats gem not installing

### DIFF
--- a/site-cookbooks/bosh-lite/recipes/bosh.rb
+++ b/site-cookbooks/bosh-lite/recipes/bosh.rb
@@ -31,6 +31,10 @@ node.set['postgresql']['config']['ssl'] = false
 include_recipe 'postgresql::server'
 include_recipe 'postgresql::ruby'
 
+rbenv_gem "eventmachine" do
+  version "0.12.10"
+end
+
 %w(pg nats bundler).each do |gem|
   rbenv_gem gem
 end


### PR DESCRIPTION
This error appeared today and halts the `vagrant up` provisioning process:

```
================================================================================
Error executing action `install` on resource 'rbenv_gem[nats]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /opt/rbenv/versions/1.9.3-p448/bin/gem install nats -q --no-rdoc --no-ri  -v "0.4.28"  ----
STDOUT: 
STDERR: ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: nats requires eventmachine (= 0.12.10)
---- End output of /opt/rbenv/versions/1.9.3-p448/bin/gem install nats -q --no-rdoc --no-ri  -v "0.4.28"  ----
Ran /opt/rbenv/versions/1.9.3-p448/bin/gem install nats -q --no-rdoc --no-ri  -v "0.4.28"  returned 1


Cookbook Trace:
---------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/rbenv/libraries/provider_rbenv_rubygems.rb:69:in `install_via_gem_command'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/rbenv/libraries/provider_rbenv_rubygems.rb:52:in `install_package'


Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-2/cookbooks/bosh-lite/recipes/bosh.rb

 35:   rbenv_gem gem
 36: end



Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-2/cookbooks/bosh-lite/recipes/bosh.rb:35:in `block in from_file'

rbenv_gem("nats") do
  provider Chef::Provider::Package::RbenvRubygems
  action :install
  retries 0
  retry_delay 2
  cookbook_name :"bosh-lite"
  recipe_name "bosh"
  version "0.4.28"
  package_name "nats"
  gem_binary "/opt/vagrant_ruby/bin/gem"
end



[2013-10-02T22:19:00+00:00] INFO: Running queued delayed notifications before re-raising exception
[2013-10-02T22:19:00+00:00] ERROR: Running exception handlers
[2013-10-02T22:19:00+00:00] ERROR: Exception handlers complete
[2013-10-02T22:19:00+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-10-02T22:19:00+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
No error message
```
