### PR TITLE
Add loggregator.incoming_port to cf stub file

### DIFF
--- a/manifests/cf-stub.yml
+++ b/manifests/cf-stub.yml
@@ -73,3 +73,6 @@ properties:
         name: uaadb
         citext: true
 
+  loggregator:
+    incoming_port: 3456
+


### PR DESCRIPTION
The cf release repo add a property (properties.loggregator.incoming_port)  in the template of cf-aws-template.yml.erb
The change is here:
https://github.com/cloudfoundry/cf-release/commit/1a0279014e1c630c0f8544dbdf94d987f790480d

This will result the failure of "bosh diff [cf-release]/templates/cf-aws-template.yml.erb and ./scripts/transform.rb -f manifests/[your-name-manifest].yml" and also could explain the issue #29.

The fix is to add the property in cf-stub.yml
