### PR TITLE
Fix the transform.rb to include dea_next log aggregator property

### DIFF
--- a/scripts/transform.rb
+++ b/scripts/transform.rb
@@ -42,7 +42,6 @@ if options[:file]
       # simplify dea network
       job['networks'][0].delete('default')
       # add disk quota properties
-      job['properties'] = {}
       job['properties']['disk_quota_enabled'] = false
 
     when 'router'


### PR DESCRIPTION
With the most updated cf-release and follow the instruction of bosh-lite.

"bosh deploy" will result:

Preparing configuration
  binding configuration: Error filling in template `dea_logging_agent.json.erb' for`dea_next/0' (line 3: Can't find property `["loggregator.trafficcontroller"]') (00:00:02).

The problem is the script/transform.rb delete all the properties in dea_next job (only has loggregator.trafficcontroller property from cf-aws-template.yml.erb). The fix will make the "bosh deploy" going through.

-Shaozhen 
