### PR TITLE
add-route: add full warden network range

### DIFF
--- a/scripts/add-route
+++ b/scripts/add-route
@@ -3,8 +3,8 @@
 echo "Adding the following route entry to your local route table to enable direct warden container access. Your sudo password may be required."
 echo "  - net 10.244.0.0/24 via 192.168.50.4"
 if [ `uname` = "Darwin" ]; then
- sudo route delete -net 10.244.0.0/24 192.168.50.4 > /dev/null 2>&1
- sudo route add -net 10.244.0.0/24 192.168.50.4
+ sudo route delete -net 10.244.0.0/22 192.168.50.4 > /dev/null 2>&1
+ sudo route add -net 10.244.0.0/22 192.168.50.4
 elif [ `uname` = "Linux" ]; then
- sudo route add -net 10.244.0.0/24 gw 192.168.50.4
+ sudo route add -net 10.244.0.0/22 gw 192.168.50.4
 fi


### PR DESCRIPTION
The network starts at .0.0, and Warden is configured to have a pool size of
256, so the actual range is .0.0/22 as each container is a /30.
