### PR TITLE
Delete any route to the 10.244.0.0/22 network

### DIFF
--- a/scripts/add-route
+++ b/scripts/add-route
@@ -3,7 +3,7 @@
 echo "Adding the following route entry to your local route table to enable direct warden container access. Your sudo password may be required."
 echo "  - net 10.244.0.0/24 via 192.168.50.4"
 if [ `uname` = "Darwin" ]; then
- sudo route delete -net 10.244.0.0/22 192.168.50.4 > /dev/null 2>&1
+ sudo route delete -net 10.244.0.0/22 > /dev/null 2>&1
  sudo route add -net 10.244.0.0/22 192.168.50.4
 elif [ `uname` = "Linux" ]; then
  sudo route add -net 10.244.0.0/22 gw 192.168.50.4


### PR DESCRIPTION
Delete route to 10.244.0.0/22 regardless of the next hop. This seems to work fine on OS X.8.5 despite unclear documentation in the man page.
