### PR TITLE
Enable callers outside of bosh-lite directory

### DIFF
--- a/scripts/make_manifest_spiff
+++ b/scripts/make_manifest_spiff
@@ -8,6 +8,7 @@ if [[ ! -d $CF_RELEASE_DIR ]]; then
   exit 1
 fi
 
+BOSH_LITE_HOME=$(dirname $0)/..
 BOSH_STATUS=$(bosh status)
 EXPECTED_DIRECTOR_NAME="Bosh Lite Director"
 DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
@@ -17,16 +18,22 @@ if [[ "$(echo "$BOSH_STATUS" | grep Name)" != *"$EXPECTED_DIRECTOR_NAME"* ]]; th
   exit 1
 fi
 
-mkdir -p tmp
-cp manifests/cf-stub-spiff.yml tmp/cf-stub-with-uuid.yml
+temp_dir=$TMPDIR/boshlite-$$.tmp
+mkdir -p $temp_dir
+
+cp $BOSH_LITE_HOME/manifests/cf-stub-spiff.yml $temp_dir/cf-stub-with-uuid.yml
+
 echo $DIRECTOR_UUID
-perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" tmp/cf-stub-with-uuid.yml
+perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" $temp_dir/cf-stub-with-uuid.yml
 
 $CF_RELEASE_DIR/generate_deployment_manifest \
                                               warden \
-                                              tmp/cf-stub-with-uuid.yml \
+                                              $temp_dir/cf-stub-with-uuid.yml \
                                               $CF_RELEASE_DIR/templates/cf-minimal-dev.yml \
-                                              $* > manifests/cf-manifest.yml
+                                              $* > $BOSH_LITE_HOME/manifests/cf-manifest.yml
 
-bosh deployment manifests/cf-manifest.yml
+rm -f $temp_dir/*
+rmdir $temp_dir
+
+bosh deployment $BOSH_LITE_HOME/manifests/cf-manifest.yml
 bosh status


### PR DESCRIPTION
I keep trying ot run make_manifest_spiff from the cf-release directory
and running into the following:

  ../bosh-lite/scripts/make_manifest_spiff
  cp: cannot stat `manifests/cf-stub-spiff.yml': No such file or directory

Using paths relative to the script helps resolve this inconvenience.
