### PR TITLE
Include missing 'bosh deployment manifests/cf-manifest.yml' in CF deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ $ bosh download public stemcell bosh-stemcell-24-warden-boshlite-ubuntu.tgz
 1.  Deploy CF to bosh-lite
 
     ```
+    cd ~/workspace/bosh-lite
+    bosh deployment manifests/cf-manifest.yml
     bosh deploy
     # enter yes to confirm
     ```


### PR DESCRIPTION
Was helping one of our PSO consultants ramp up on bosh-lite. He was confused that "bosh deploy" kept saying he must choose a deployment first. I noticed that step was missing from the instructions and added it.
