### PR TITLE
make_manifest_spiff should not assume TMPDIR is set

### DIFF
--- a/scripts/make_manifest_spiff
+++ b/scripts/make_manifest_spiff
@@ -18,7 +18,7 @@ if [[ "$(echo "$BOSH_STATUS" | grep Name)" != *"$EXPECTED_DIRECTOR_NAME"* ]]; th
   exit 1
 fi
 
-temp_dir=$TMPDIR/boshlite-$$.tmp
+temp_dir=${TMPDIR:-${BOSH_LITE_HOME}/tmp}/boshlite-$$.tmp
 mkdir -p $temp_dir
 
 cp $BOSH_LITE_HOME/manifests/cf-stub-spiff.yml $temp_dir/cf-stub-with-uuid.yml


### PR DESCRIPTION
On my Ubuntu box, `TMPDIR` is not set, which causes `make_manifest_spiff` to try to create a directory under `/` which it doesn't have permission to do. As there is no error checking in the script it carries on regardless, but fails to work.

This PR ensures that `temp_dir` is set to something valid even if `TMPDIR` is not set

I don't think there is a sensible system-wide default for TMPDIR that is properly cross platform - so have used `BOSH_LITE_HOME/tmp` as the fallback default.
