### PR TITLE
Upgrading the net-ssh-gateway version in the Gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.7.0)
-    net-ssh-gateway (1.1.2)
+    net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.1)
       net-ssh (>= 2.1.4)


### PR DESCRIPTION
1.1.2 got yanked from rubygems.org: http://rubygems.org/gems/net-ssh-gateway/versions
