### PR TITLE
Enable NFS from vagrant host to test NFS issue on bosh-lite

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,4 +20,12 @@ Vagrant.configure('2') do |config|
     v.vmx["memsize"] = VM_MEMORY
   end
 
+  if ENV["LOCAL_PROVISION"]
+    config.vm.provision :chef_solo do |chef|
+      chef.cookbooks_path = ['./cookbooks', './site-cookbooks']
+      chef.log_level = :debug
+      chef.add_recipe 'bosh-lite::warden'
+      chef.add_recipe 'bosh-lite::bosh'
+    end
+  end
 end

--- a/site-cookbooks/bosh-lite/recipes/bosh.rb
+++ b/site-cookbooks/bosh-lite/recipes/bosh.rb
@@ -14,6 +14,7 @@ include_recipe 'nginx::repo'
   package package_name
 end
 
+include_recipe 'bosh-lite::nfs_server'
 include_recipe 'bosh-lite::rbenv'
 
 include_recipe 'runit'

--- a/site-cookbooks/bosh-lite/recipes/nfs_server.rb
+++ b/site-cookbooks/bosh-lite/recipes/nfs_server.rb
@@ -1,0 +1,17 @@
+# Install an NFS server for use by CloudFoundry
+nfs_export = '/export/blobstore'
+
+directory ::File.join(nfs_export, 'shared') do
+  mode 0755
+  action :create
+  recursive true
+end
+
+template '/etc/exports' do
+  source 'exports.erb'
+  mode 0755
+  owner 'vagrant'
+  variables(nfs_export: nfs_export)
+end
+
+package 'nfs-kernel-server'

--- a/site-cookbooks/bosh-lite/templates/default/exports.erb
+++ b/site-cookbooks/bosh-lite/templates/default/exports.erb
@@ -1,0 +1,1 @@
+<%= @nfs_export %> *(rw,no_root_squash)


### PR DESCRIPTION
- Bosh-lite host exports NFS mount for CF to use.
- Added ability to provision with top level vagrant file.

Signed-off-by: Aram Price aprice@pivotallabs.com
