### PR TITLE
Ignore go-agent stemcells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ cookbooks
 .vagrant
 pkg/
 manifests/cf-manifest.yml
-bosh-stemcell-*-warden-boshlite-ubuntu.tgz
+bosh-stemcell-*-warden-boshlite-*.tgz


### PR DESCRIPTION
New stemcell names have the agent and the ubuntu version - modify ignore to include these.
