### PR TITLE
Add dummy box url.

### DIFF
--- a/aws/Vagrantfile
+++ b/aws/Vagrantfile
@@ -4,6 +4,7 @@ Vagrant.configure('2') do |config|
   env = ENV.to_hash
 
   config.vm.box = 'dummy'
+  config.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/blob/master/dummy.box?raw=true'
   config.vm.provider :aws do |aws, override|
     aws.access_key_id =       env.fetch('BOSH_AWS_ACCESS_KEY_ID')
     aws.secret_access_key =   env.fetch('BOSH_AWS_SECRET_ACCESS_KEY')


### PR DESCRIPTION
This eliminates the step of 'vagrant box add' making bosh lite
less stateful and easier to automate.
