### PR TITLE
Fix problem running 'bundle' with Ruby 2.0.0 (on osx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '1.9.3'
-
 gem 'librarian-chef'
 gem 'bosh_cli'
 


### PR DESCRIPTION
Remove hard coded 1.9.3
