### PR TITLE
Add bare-metal support

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -1,0 +1,4 @@
+cookbook_path    ["cookbooks", "site-cookbooks"]
+node_path        "nodes"
+
+knife[:berkshelf_path] = "cookbooks"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ cookbooks
 pkg/
 manifests/cf-manifest.yml
 bosh-stemcell-*-warden-boshlite-*.tgz
+/cookbooks/
+/tmp/librarian/
+/nodes/*.json
+!/nodes/example_node.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'librarian-chef'
+gem 'knife-solo'
 gem 'bosh_cli'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,10 @@ GEM
     ipaddress (0.8.0)
     json (1.8.1)
     json_pure (1.8.1)
+    knife-solo (0.4.2)
+      chef (>= 10.12)
+      erubis (~> 2.7.0)
+      net-ssh (>= 2.2.2, < 3.0)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -148,6 +152,7 @@ PLATFORMS
 
 DEPENDENCIES
   bosh_cli
+  knife-solo
   librarian-chef
   rake
   rspec

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For all use cases, first prepare this project with `bundler` .
     ```
 
     See [this blog](http://aliwahaj.blogspot.de/2014/01/installing-cloud-foundry-on-vagrant.html) for special instructions for Windows users of BOSH Lite.
+    This step can be skipped when using bare-metal.
 
 1. Install Ruby + RubyGems + Bundler.
 
@@ -30,7 +31,7 @@ For all use cases, first prepare this project with `bundler` .
     bundle
     ```
 
-### Install and Boot a Virtual Machine
+### Install and Boot a (Virtual) Machine
 
 Below are installation instructions for different Vagrant providers.
 
@@ -38,6 +39,7 @@ Below are installation instructions for different Vagrant providers.
 * Virtualbox
 * AWS
 
+Additionally there are instructions for installing bosh-lite on bare-metal.
 
 #### Using the VMWare Fusion Provider (preferred)
 
@@ -183,6 +185,30 @@ These rules are cleared on restart. They can be saved and configured to be reloa
 |BOSH_LITE_SECURITY_GROUP       |AWS security group                   |inception|
 |BOSH_LITE_PRIVATE_KEY          |path to private key matching keypair |~/.ssh/id_rsa_bosh|
 |[VPC only] BOSH_LITE_SUBNET_ID |AWS VPC subnet ID                    | |
+
+#### Using knife solo on a bare-metal Ubuntu box
+
+This guide assumes you have already installed `Ubuntu Server 12.04 LTS (64-bit)` on your box.
+And have correctly configured ssh access.
+
+1. Prepare you box by installing chef
+
+```
+STATIC_IP=<ip of your box>
+knife solo prepare root@$STATIC_IP
+```
+
+2. Edit the created node file
+
+```
+sed "s/STATIC_IP/$STATIC_IP/g" nodes/example_node.json > nodes/$STATIC_IP.json
+```
+
+3. Install bosh-lite
+
+```
+knife solo cook root@$STATIC_IP
+```
 
 ## Restart the Director
 

--- a/nodes/example_node.json
+++ b/nodes/example_node.json
@@ -1,0 +1,10 @@
+{
+  "run_list": [
+      "bosh-lite::warden",
+      "bosh-lite::bosh"
+  ],
+  "boshlite": { 
+      "enable_compiled_package_cache": true,
+      "director_ip": STATIC_IP
+  }
+}


### PR DESCRIPTION
This PR add support for installing bosh-lite on a bare-metal box.
A use-case for this could be an lap environment.

The [knife solo gem](http://matschaffer.github.io/knife-solo/) is used for provisioning the bare-metal machine after ubuntu has been manually installed.
