### PR TITLE
Modified provision_cf so that it clones the cf-release repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ $ bosh ssh
 Choose an instance:
 ```
 
+Note: `bosh shh` automatically finds and uses the first key from your ssh keychain. If you do not have any RSA keys, you must create one. In a unix environment, this can be accomplished using `ssh-keygen`. You can then and add it to your keychain or you can pass the public key file to the command `bosh ssh --public_key /path/of/public/key`.
+
 ### For AWS provider:
 
 SSH into any VM with `bosh ssh` providing `--gateway_identity_file, --gateway_host and --gateway_user`

--- a/scripts/provision_cf
+++ b/scripts/provision_cf
@@ -12,8 +12,13 @@ BOSH_LITE_IP=$(cat "${BOSH_LITE_DIR}/Vagrantfile" | awk -F"'" '/private_network/
 main() {
   fetch_stemcell
   upload_stemcell
+  cloneCF
   build_manifest
   deploy_release
+}
+
+cloneCF() {
+  git clone https://github.com/cloudfoundry/cf-release.git
 }
 
 fetch_stemcell() {


### PR DESCRIPTION
This PR is a replacement for the PR associated with https://www.pivotaltracker.com/story/show/74733740.  After many mistakes using git, I gave up and completely redid my fork, and thus needed a new PR.  Previously, collaborators had said:

@programsam Thanks for the PR.

    The git URL does not look correct - shouldn't it be https://github.com/cloudfoundry/cf-release
    What if someone already has cf-release checked out and wants to use that specific version?

To the first point: I have fixed the URL, thank you.

To the second point: I created this PR to help address https://github.com/cloudfoundry/bosh-lite/issues/110 because the error message was occurring because I hadn't cloned the cf-release directory.  This seems like the most logical response.  However, the script appears to (https://github.com/cloudfoundry/bosh-lite/blob/master/scripts/provision_cf#L41) always look for the most recent CF release.  So if you checkout v169, for example, the script should obtain the release.yml for 169.