### PR TITLE
Ignore Bundler binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ cookbooks
 pkg/
 manifests/cf-manifest.yml
 bosh-stemcell-*-warden-boshlite-*.tgz
+bin/*
+.bundle/config


### PR DESCRIPTION
This is a somewhat opinionated change. With these files ignored, the users who choose to use

```
bundle install --binstubs
```

to install dependencies won't have `git status` polluted with unknown, machine-generated files.
