### PR TITLE
Revert chef version to avoid issues with pg gem

### DIFF
--- a/boxes/template/boshlite-ubuntu1204/aws.json
+++ b/boxes/template/boshlite-ubuntu1204/aws.json
@@ -29,6 +29,7 @@
   },
   {
      "type": "chef-solo",
+     "install_command": "curl -L https://www.opscode.com/chef/install.sh | {{if .Sudo}}sudo{{end}} bash  -s -- -v 11.12.8",
      "cookbook_paths": ["../../../cookbooks", "../../../site-cookbooks"],
      "run_list": ["bosh-lite::warden", "bosh-lite::bosh", "bosh-lite::bosh_cli", "bosh-lite::aws_files", "bosh-lite::update-kernel"],
      "json": {

--- a/boxes/template/boshlite-ubuntu1204/openstack.json
+++ b/boxes/template/boshlite-ubuntu1204/openstack.json
@@ -28,6 +28,7 @@
   },
   {
      "type": "chef-solo",
+     "install_command": "curl -L https://www.opscode.com/chef/install.sh | {{if .Sudo}}sudo{{end}} bash  -s -- -v 11.12.8",
      "cookbook_paths": ["../../../cookbooks", "../../../site-cookbooks"],
      "run_list": ["bosh-lite::warden", "bosh-lite::bosh", "bosh-lite::bosh_cli"],
      "json": {

--- a/boxes/template/boshlite-ubuntu1204/script/base.sh
+++ b/boxes/template/boshlite-ubuntu1204/script/base.sh
@@ -10,15 +10,7 @@ chmod 0440 /tmp/packer
 mv /tmp/packer /etc/sudoers.d/
 
 apt-get -y update
-#apt-get -y upgrade
-#apt-get -y install curl
 apt-get clean
-
-( cat  <<'EOP'
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "0";
-EOP
-) >  /etc/apt/apt.conf.d/10periodic
 
 # libpq is required by the pg gem which is required by the postgresql chef recipe
 # This is a workaround to avoid forking the postgresql cookbook

--- a/boxes/template/boshlite-ubuntu1204/template.json
+++ b/boxes/template/boshlite-ubuntu1204/template.json
@@ -97,6 +97,7 @@
   },
   {
      "type": "chef-solo",
+     "install_command": "curl -L https://www.opscode.com/chef/install.sh | {{if .Sudo}}sudo{{end}} bash  -s -- -v 11.12.8",
      "cookbook_paths": ["../../../cookbooks", "../../../site-cookbooks"],
      "run_list": ["bosh-lite::warden", "bosh-lite::bosh"],
      "json": {

--- a/boxes/template/boshlite-withcf-ubuntu1204/aws.json
+++ b/boxes/template/boshlite-withcf-ubuntu1204/aws.json
@@ -30,6 +30,7 @@
   },
   {
      "type": "chef-solo",
+     "install_command": "curl -L https://www.opscode.com/chef/install.sh | {{if .Sudo}}sudo{{end}} bash  -s -- -v 11.12.8",
      "cookbook_paths": ["../../../cookbooks", "../../../site-cookbooks"],
      "run_list": ["bosh-lite::warden", "bosh-lite::bosh", "bosh-lite::bosh_cli", "bosh-lite::aws_files", "bosh-lite::update-kernel", "bosh-lite::repos"],
      "json": {

--- a/boxes/template/boshlite-withcf-ubuntu1204/script/base.sh
+++ b/boxes/template/boshlite-withcf-ubuntu1204/script/base.sh
@@ -8,12 +8,4 @@ chmod 0440 /tmp/packer
 mv /tmp/packer /etc/sudoers.d/
 
 apt-get -y update
-#apt-get -y upgrade
-#apt-get -y install curl
 apt-get clean
-
-( cat  <<'EOP'
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "0";
-EOP
-) >  /etc/apt/apt.conf.d/20auto-upgrades

--- a/boxes/template/boshlite-withcf-ubuntu1204/template.json
+++ b/boxes/template/boshlite-withcf-ubuntu1204/template.json
@@ -96,6 +96,7 @@
   },
   {
      "type": "chef-solo",
+     "install_command": "curl -L https://www.opscode.com/chef/install.sh | {{if .Sudo}}sudo{{end}} bash  -s -- -v 11.12.8",
      "cookbook_paths": ["../../../cookbooks", "../../../site-cookbooks"],
      "run_list": ["bosh-lite::warden", "bosh-lite::bosh", "bosh-lite::bosh_cli", "bosh-lite::repos"],
      "json": {


### PR DESCRIPTION
The pg-ruby recipe contains a retry path that handles incompatible SSL
versions but newer versions of the chef_gem recipe break it.  By moving
to an older version of chef, we can avoid the problem.  Given we don't
really have any hard dependencies on chef versions, this is a quick way
to get things working again.

Another issue that's been addressed is the conflict between the periodic
update configuration introduced in base.sh and that managed by the
cookbooks.  Removing the code from `base.sh` seems to resolve this.
