### PR TITLE
Bring bosh-lite configuration up to date with recent bosh

### DIFF
--- a/boxes/template/boshlite-ubuntu1204/script/cleanup.sh
+++ b/boxes/template/boshlite-ubuntu1204/script/cleanup.sh
@@ -19,3 +19,12 @@ if [ -d "/var/lib/dhcp" ]; then
 fi
 
 apt-get clean
+
+echo "cleaning up chef"
+dpkg -P chef
+rm -rf /var/chef
+rm -rf /opt/chef
+rm -rf /etc/chef
+
+echo "cleaning up logs"
+find /var/log -type f | xargs rm -f

--- a/site-cookbooks/bosh-lite/files/default/nginx.conf
+++ b/site-cookbooks/bosh-lite/files/default/nginx.conf
@@ -2,33 +2,80 @@ user vagrant;
 worker_processes  4;
 daemon on;
 
-pid        /var/run/nginx.pid;
+error_log /var/log/nginx/error.log;
+pid       /var/run/nginx.pid;
 
 events {
   worker_connections  8192;
 }
 
 http {
-  include       /etc/nginx/mime.types;
-  default_type  text/html;
+  include      /etc/nginx/mime.types;
+  default_type text/html;
+
+  log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+                            '"$request" $status $body_bytes_sent '
+                            '"$http_referer" "$http_user_agent" '
+                            '$request_time $upstream_response_time $pipe';
+
+  access_log    /var/log/nginx/access.log timed_combined;
   server_tokens off;
+
+  sendfile    off;
+  tcp_nopush  on;
+  tcp_nodelay on;
+
+  keepalive_timeout    7200;
+  client_max_body_size 5G;
+
+  upstream director {
+    server 127.0.0.1:21085;
+  }
 
   server {
     listen 25555;
 
+    ssl                 on;
+    ssl_certificate     /etc/nginx/ssl/director.pem;
+    ssl_certificate_key /etc/nginx/ssl/director.key;
+    ssl_session_timeout 7200;
+
+    proxy_set_header    Host              $host;
+    proxy_set_header    X-Real-IP         $remote_addr;
+    proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header    X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout       300;
+    proxy_max_temp_file_size 0;
+
     location / {
-      proxy_pass         http://127.0.0.1:21085;
-      proxy_set_header   Host             $host;
-      proxy_set_header   X-Real-IP        $remote_addr;
-      proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Proto $scheme;
-      proxy_read_timeout 300;
+      proxy_pass http://director;
+
+      if ($content_type = "application/x-compressed") {
+        more_set_input_headers "Content-Disposition: attachment";
+
+        # Pass altered request body to this location
+        upload_pass @director_upload;
+
+        upload_resumable on;
+
+        # Store files to this directory
+        upload_store /tmp/director/;
+
+        # Allow uploaded files to be read only by user
+        upload_store_access user:r;
+
+        # Set specified fields in request body
+        upload_set_form_field "nginx_upload_path" $upload_tmp_path;
+
+        # On any error, delete uploaded files.
+        upload_cleanup 400-505;
+      }
     }
 
-    ssl on;
-    ssl_certificate           /etc/nginx/ssl/director.pem;
-    ssl_certificate_key       /etc/nginx/ssl/director.key;
-    ssl_session_timeout       7200;
+    location @director_upload {
+      proxy_pass http://director;
+    }
   }
 
   server {
@@ -54,17 +101,6 @@ http {
     }
   }
 
-
-  access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
-
-  sendfile             on;
-  tcp_nopush           on;
-  tcp_nodelay          on;
-
-  keepalive_timeout    7200;
-  client_max_body_size 5000m;
-
   gzip                 on;
   gzip_min_length      1250;
   gzip_buffers         16 8k;
@@ -73,5 +109,4 @@ http {
   gzip_types           text/plain text/css application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
   gzip_vary            on;
   gzip_disable         "MSIE [1-6]\.(?!.*SV1)";
-
 }

--- a/site-cookbooks/bosh-lite/files/default/warden-cpi-vm.yml
+++ b/site-cookbooks/bosh-lite/files/default/warden-cpi-vm.yml
@@ -45,6 +45,12 @@ logging:
   level: debug2
 
 network:
+  # Containers access the director
+  allow_host_access: true
+
+  allow_networks:
+    - 0.0.0.0/0
+
   # Use this /30 network as offset for the network pool.
   pool_start_address: 10.244.0.0
 

--- a/site-cookbooks/bosh-lite/recipes/nginx.rb
+++ b/site-cookbooks/bosh-lite/recipes/nginx.rb
@@ -1,0 +1,112 @@
+# Use source blobs from cf-release to construct nginx since it
+# appears that there have been some modifications (to the upload
+# module in particular) that are not present in the official
+# repositories.
+#
+# These versions and hashes match what are used by bosh.
+
+cache_path = Chef::Config[:file_cache_path]
+nginx_tarball = 'nginx-1.4.5.tar.gz'
+headers_more_tarball = 'headers-more-v0.25.tgz'
+upload_module_tarball = 'nginx-upload-module-2.2.tar.gz'
+pcre_tarball = 'pcre-8.34.tar.gz'
+
+remote_file nginx_tarball do
+  source 'https://blob.cfblob.com/8001e14c-1629-4305-bd5a-02e6ec9faa04'
+  path File.join(cache_path, nginx_tarball)
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+end
+
+remote_file headers_more_tarball do
+  source 'https://blob.cfblob.com/a621718d-df24-4205-ba31-6ed8a212732e'
+  path File.join(cache_path, headers_more_tarball)
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+end
+
+remote_file upload_module_tarball do
+  source 'https://blob.cfblob.com/502854f1-9823-468f-baef-1a8d68823ead'
+  path File.join(cache_path, upload_module_tarball)
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+end
+
+remote_file pcre_tarball do
+  source 'https://blob.cfblob.com/ee5bee99-dda0-4d81-be88-a7a1a901dae7'
+  path File.join(cache_path, pcre_tarball)
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+end
+
+bash "build nginx" do
+  cwd cache_path
+  code <<-EOF
+    set -e
+
+    tar zxvf #{nginx_tarball}
+    tar zxvf #{headers_more_tarball}
+    tar zxvf #{upload_module_tarball}
+    tar zxvf #{pcre_tarball}
+
+    pushd nginx-1.4.5
+      ./configure \
+        --prefix=/etc/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --sbin-path=/usr/sbin/nginx \
+        --with-pcre=../pcre-8.34 \
+        --with-http_ssl_module \
+        --with-http_dav_module \
+        --add-module=../headers-more-nginx-module-0.25 \
+        --add-module=../nginx-upload-module-2.2
+
+      make
+      make install
+    popd
+  EOF
+  not_if { ::File.exists?('/usr/sbin/nginx') }
+end
+
+node.set['nginx']['dir'] = '/etc/nginx'
+node.set['nginx']['binary'] = '/usr/sbin/nginx'
+node.set['nginx']['pid'] = '/var/run/nginx.pid'
+node.set['nginx']['user'] = 'vagrant'
+
+include_recipe 'nginx::commons_dir'
+
+template '/etc/init.d/nginx' do
+  source 'nginx.init.erb'
+  cookbook 'nginx'
+  variables :src_binary => node['nginx']['binary'], :pid => node['nginx']['pid']
+  owner 'root'
+  group node['root_group']
+  mode '0755'
+end
+
+%w(nginx.conf read_users write_users).each do |file|
+  cookbook_file "/etc/nginx/#{file}" do
+    mode 0755
+  end
+end
+
+directory '/etc/nginx/ssl' do
+  mode 0755
+  action :create
+end
+
+execute 'create director ssl key and csr' do
+  command 'openssl req -nodes -new -newkey rsa:1024 -out /etc/nginx/ssl/director.csr -keyout /etc/nginx/ssl/director.key -subj \'/O=Bosh/CN=*\''
+end
+
+execute 'self sign director ssl csr' do
+  command 'openssl x509 -req -days 3650 -in /etc/nginx/ssl/director.csr -signkey /etc/nginx/ssl/director.key -out /etc/nginx/ssl/director.pem'
+end
+
+service 'nginx' do
+  supports :status => true, :restart => true, :reload => true
+  action   [ :enable, :restart ]
+end


### PR DESCRIPTION
Build a custom nginx based on the bosh release
- Create custom bosh-lite::nginx recipe
  - Use source blobs from cf-release for nginx and the required modules
  - Use modified packaging script to build nginx
  - Use nginx configuration from bosh release
- Extend cleanup to remove chef artifacts from bosh
- Update warden configuration to disable host network isolation

When combined with https://github.com/cloudfoundry/bosh-lite/pull/158, we get a functional bosh lite with an up to date bosh version (1.2697.0).
