### PR TITLE
latest-bosh-stemcell-warden points to a stemcell that doesn't work out of the box

### DIFF
--- a/scripts/provision_cf
+++ b/scripts/provision_cf
@@ -3,7 +3,7 @@
 set -xe
 
 STEMCELL_SOURCE=http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/warden
-STEMCELL_FILE=latest-bosh-stemcell-warden.tgz
+STEMCELL_FILE=bosh-stemcell-21-warden-boshlite-ubuntu-trusty-go_agent.tgz
 WORKSPACE_DIR="$(cd $(dirname ${BASH_SOURCE[0]})/../../ && pwd)"
 BOSH_LITE_DIR="${WORKSPACE_DIR}/bosh-lite"
 CF_DIR="${WORKSPACE_DIR}/cf-release"


### PR DESCRIPTION
This is not a problem with the script per se, but the defaults don't work. We can either link latest-bosh-stemcell-warden.tgz to the Trusty one or create a new latest-bosh-trusty-stemcell-warden.tgz link. Up for discussion.

Signed-off-by: Chris Hedley chris@cghsystems.net
