### PR TITLE
Remove provider config from main Vagrantfile and embed inside box

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Below are installation instructions for different Vagrant providers.
 1. Start Vagrant from the base directory of this repository. This uses the Vagrantfile.
 
     ```
-    vagrant up local --provider=virtualbox
+    vagrant up --provider=virtualbox
     ```
 
 1. Target the BOSH Director and login with admin/admin.
@@ -100,7 +100,7 @@ VMware boxes are not currently published and will need to be built locally.
 1. Start Vagrant from the base directory of this repository. This uses the Vagrantfile.
 
     ```
-    vagrant up local --provider=vmware_fusion
+    vagrant up --provider=vmware_fusion
     ```
 
 1. Target the BOSH Director and login with admin/admin.
@@ -162,7 +162,7 @@ AWS Environment Variables:
 * Run vagrant up with provider `aws`:
 
     ```
-    vagrant up remote --provider=aws
+    vagrant up --provider=aws
     ```
 
 * Find out the public IP of the box you just launched. You can see this info at the end of `vagrant up` output. Another way is running `vagrant ssh-config remote`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,87 +1,9 @@
-VM_MEMORY = ENV.fetch('VM_MEMORY', 6*1024).to_i
-VM_CORES = ENV.fetch('VM_CORES', 4).to_i
-
-# better error messages from Hash.fetch
-env = ENV.to_hash
-
-def tags_from_environment(env)
-  values = [env.fetch('BOSH_LITE_NAME', 'Vagrant')]
-  values.concat env.fetch('BOSH_LITE_TAG_VALUES', '').chomp.split(', ')
-
-  keys = ['Name']
-  keys.concat env.fetch('BOSH_LITE_TAG_KEYS', '').chomp.split(', ')
-
-  raise 'Please provide the same number of keys and values!' if keys.length != values.length
-
-  Hash[keys.zip(values)]
-end
-
 Vagrant.configure('2') do |config|
-  config.vm.define :local do |local|
-    local.vm.network :private_network, ip: '192.168.50.4'
-    local.vm.box = 'bosh-lite-ubuntu-trusty'
+  config.vm.define 'bosh-lite'
+  config.vm.box = 'bosh-lite-ubuntu-trusty'
 
-    local.vm.hostname='bosh-lite'
-
-    local.vm.provider :virtualbox do |v, override|
-      #CDN in front of bosh-lite-build-artifacts.s3.amazonaws.com
-      override.vm.box_url = 'http://d3a4sadvqj176z.cloudfront.net/bosh-lite/latest/bosh-lite-virtualbox-ubuntu-14-04-0.box'
-      v.customize ['modifyvm', :id, '--memory', VM_MEMORY]
-      v.customize ['modifyvm', :id, '--cpus', VM_CORES]
-      v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-      v.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-    end
-
-    [:vmware_fusion, :vmware_desktop, :vmware_workstation].each do |provider|
-      local.vm.provider provider do |v, override|
-        v.vmx["numvcpus"] = VM_CORES
-        v.vmx["memsize"] = VM_MEMORY
-      end
-    end
-  end
-
-  config.vm.define :remote do |remote|
-    remote.vm.box = 'bosh-lite-aws-ubuntu-trusty'
-    remote.vm.synced_folder '.', '/vagrant', disabled: true
-    remote.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/blob/master/dummy.box?raw=true'
-
-    remote.vm.provision :shell, :inline => "chmod 777 /tmp", :upload_path => '/opt/bosh-provisioner/packer-shell.sh'
-    remote.vm.provider :aws do |v, override|
-      v.access_key_id =       env.fetch('BOSH_AWS_ACCESS_KEY_ID')
-      v.secret_access_key =   env.fetch('BOSH_AWS_SECRET_ACCESS_KEY')
-
-      v.keypair_name =        env.fetch('BOSH_LITE_KEYPAIR', 'bosh')
-
-      v.ami = `curl -s https://bosh-lite-build-artifacts.s3.amazonaws.com/ami/bosh-lite-ami.list |tail -1`.chop
-      v.block_device_mapping = [
-          {
-            :DeviceName => '/dev/sda1',
-            'Ebs.VolumeSize' => env.fetch('BOSH_LITE_DISK_SIZE', '50').to_i
-          }
-      ]
-      v.instance_type =       env.fetch('BOSH_LITE_INSTANCE_TYPE', 'm3.xlarge')
-      
-      v.tags =                tags_from_environment(env)
-      # use SG-names when deploying to EC2 classic but SG-IDs when deploying to a VPC
-      v.security_groups = [   env.fetch('BOSH_LITE_SECURITY_GROUP', 'inception') ]
-
-      v.subnet_id =           env.fetch('BOSH_LITE_SUBNET_ID') if env.include?('BOSH_LITE_SUBNET_ID')
-
-      override.ssh.username = 'ubuntu'
-      override.ssh.private_key_path = env.fetch('BOSH_LITE_PRIVATE_KEY', '~/.ssh/id_rsa_bosh')
-    end
-
-    PORT_FORWARDING = <<-IP_SCRIPT
-public_ip=`curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
-echo "The public IP for this instance is $public_ip"
-echo "You can bosh target $public_ip, or run vagrant ssh and then bosh target 127.0.0.1"
-
-local_ip=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`
-echo "Setting up port forwarding for the CF Cloud Controller..."
-sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 80 -j DNAT --to 10.244.0.34:80
-sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 443 -j DNAT --to 10.244.0.34:443
-sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 4443 -j DNAT --to 10.244.0.34:4443
-    IP_SCRIPT
-    remote.vm.provision :shell, :inline => PORT_FORWARDING
+  config.vm.provider :virtualbox do |v, override|
+    #CDN in front of bosh-lite-build-artifacts.s3.amazonaws.com
+    override.vm.box_url = 'http://d3a4sadvqj176z.cloudfront.net/bosh-lite/latest/bosh-lite-virtualbox-ubuntu-14-04-0.box'
   end
 end

--- a/bin/disable_container_internet
+++ b/bin/disable_container_internet
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh local -c '
+vagrant ssh -c '
 dns_server=(`grep -Po "(?<=nameserver ).*" /etc/resolv.conf`)
 sudo iptables -t nat -F warden-postrouting
 sudo iptables -t nat -A warden-postrouting -s 10.244.0.0/19 -d $dns_server -j MASQUERADE

--- a/bin/enable_container_internet
+++ b/bin/enable_container_internet
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh local -c '
+vagrant ssh -c '
 dns_server=(`grep -Po "(?<=nameserver ).*" /etc/resolv.conf`)
 sudo iptables -t nat -F warden-postrouting
 sudo iptables -t nat -A warden-postrouting -s 10.244.0.0/19 ! -d 10.244.0.0/19  -j MASQUERADE

--- a/ci/ci-box-bats.sh
+++ b/ci/ci-box-bats.sh
@@ -12,18 +12,18 @@ export TMPDIR=$CUD
 cleanup()
 {
   cd $CUD
-  vagrant destroy local -f
+  vagrant destroy -f
 }
 
 trap cleanup EXIT
 
 echo $CANDIDATE_BUILD_NUMBER
 
-vagrant destroy local -f
+vagrant destroy -f
 rm -rf /var/lib/jenkins/.bosh_cache/* || true
 
 vagrant box add bosh-lite-virtualbox-ubuntu-trusty-${CANDIDATE_BUILD_NUMBER}.box --name bosh-lite-ubuntu-trusty --force
-vagrant up local --provider=virtualbox
+vagrant up --provider=virtualbox
 
 ./bin/add-route || true
 

--- a/ci/ci-stemcell-bats.sh
+++ b/ci/ci-stemcell-bats.sh
@@ -7,7 +7,7 @@ CUD=$(pwd)
 cleanup()
 {
   cd $CUD/bosh-lite
-  vagrant destroy local -f
+  vagrant destroy -f
 }
 
 trap cleanup EXIT

--- a/scripts/clean-up.sh
+++ b/scripts/clean-up.sh
@@ -24,5 +24,21 @@ if [ -d "/var/lib/dhcp" ]; then
 	rm /var/lib/dhcp/*
 fi
 
+echo "Cleaning up apt packages"
 apt-get -y autoremove --purge
 apt-get -y clean
+
+echo "Cleaning up apt repository cache"
+find /var/lib/apt/lists -type f | xargs rm -f
+
+echo "Cleaning up dpkg backup files"
+find /var/cache/debconf -type f -name '*-old' | xargs rm -f
+
+echo "Cleaning up old logs"
+find /var/log /var/vcap/bosh/log /var/vcap/sys/log -type f | xargs rm -f
+
+echo "Cleaning up locales"
+find /usr/share/locale -maxdepth 1 -mindepth 1 -not -name 'en*' | xargs rm -rf
+
+echo "Cleaning up /usr/share/doc"
+rm -rf /usr/share/doc/*

--- a/scripts/kernel-cleanup.sh
+++ b/scripts/kernel-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+export DEBIAN_FRONTEND=noninteractive
 
 echo "Removing kernels that do not match $(uname -r)"
 
@@ -12,3 +12,6 @@ dpkg --list | awk '{ print $2 }' | grep 'linux-headers-3.*' | grep -v `uname -r`
 
 # delete linux source
 dpkg --list | awk '{ print $2 }' | grep linux-source | xargs apt-get -y purge
+
+# miscellaneous packages
+apt-get -y purge linux-firmware

--- a/scripts/quiet-tty-warning.sh
+++ b/scripts/quiet-tty-warning.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# Add tty chack around `mesg n` so provisioners don't report `stdin: not a tty`
+cp /root/.profile /root/.profile.orig
+cat /root/.profile.orig | sed -e 's/^mesg n/tty -s \&\& mesg n/g' > /root/.profile
+rm /root/.profile.orig

--- a/templates/aws.json
+++ b/templates/aws.json
@@ -1,13 +1,14 @@
 {
   "variables": {
-    "base_ami": "ami-d2ff23ba",
+    "base_ami": "ami-acff23c4",
     "region": "us-east-1",
     "build_number": "0"
   },
   "builders": [{
     "type": "amazon-ebs",
     "ami_name": "boshlite-{{user `build_number`}}",
-    "instance_type": "m1.large",
+    "ami_virtualization_type": "hvm",
+    "instance_type": "t2.micro",
     "region": "{{user `region`}}",
     "source_ami":  "{{user `base_ami`}}",
     "ssh_username": "ubuntu",
@@ -20,8 +21,10 @@
     "type": "shell",
     "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
     "scripts": [
+      "scripts/quiet-tty-warning.sh",
       "scripts/update-sources-list.sh",
       "scripts/update-trusty-kernel.sh",
+      "scripts/kernel-cleanup.sh",
       "scripts/admin-sudoers.sh"
     ]
   },{
@@ -50,6 +53,7 @@
   "post-processors": [{
     "type": "vagrant",
     "keep_input_artifact": true,
+    "vagrantfile_template": "templates/vagrant-aws.tpl",
     "output": "bosh-lite-{{ .Provider }}-ubuntu-trusty-{{user `build_number`}}.box"
   }]
 }

--- a/templates/vagrant-aws.tpl
+++ b/templates/vagrant-aws.tpl
@@ -1,0 +1,57 @@
+# better error messages from Hash.fetch
+env = ENV.to_hash
+
+unless env.include?('BOSH_AWS_ACCESS_KEY_ID') &&  env.include?('BOSH_AWS_SECRET_ACCESS_KEY')
+  raise 'BOSH_AWS_ACCESS_KEY_ID and BOSH_AWS_SECRET_ACCESS_KEY must be provided in the environment'
+end
+
+def tags_from_environment(env)
+  values = [env.fetch('BOSH_LITE_NAME', 'Vagrant')]
+  values.concat env.fetch('BOSH_LITE_TAG_VALUES', '').chomp.split(', ')
+
+  keys = ['Name']
+  keys.concat env.fetch('BOSH_LITE_TAG_KEYS', '').chomp.split(', ')
+
+  raise 'Please provide the same number of keys and values!' if keys.length != values.length
+
+  Hash[keys.zip(values)]
+end
+
+Vagrant.configure('2') do |config|
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+  config.vm.provision :shell, :inline => "chmod 777 /tmp", :upload_path => '/opt/bosh-provisioner/packer-shell.sh'
+
+  config.vm.hostname='bosh-lite'
+  config.ssh.username = 'ubuntu'
+  config.ssh.private_key_path = env.fetch('BOSH_LITE_PRIVATE_KEY', '~/.ssh/id_rsa_bosh')
+
+  config.vm.provider :aws do |v|
+    v.access_key_id =       env.fetch('BOSH_AWS_ACCESS_KEY_ID')
+    v.secret_access_key =   env.fetch('BOSH_AWS_SECRET_ACCESS_KEY')
+    v.keypair_name =        env.fetch('BOSH_LITE_KEYPAIR', 'bosh')
+    v.block_device_mapping = [{
+      :DeviceName => '/dev/sda1',
+      'Ebs.VolumeSize' => env.fetch('BOSH_LITE_DISK_SIZE', '50').to_i
+    }]
+    v.instance_type =       env.fetch('BOSH_LITE_INSTANCE_TYPE', 'm3.xlarge')
+    v.security_groups =     [env.fetch('BOSH_LITE_SECURITY_GROUP', 'inception')]
+    v.subnet_id =           env.fetch('BOSH_LITE_SUBNET_ID') if env.include?('BOSH_LITE_SUBNET_ID')
+    v.tags =                tags_from_environment(env)
+  end
+
+  PUBLIC_IP = <<-PUBLIC_IP_SCRIPT
+public_ip=`curl -s http://169.254.169.254/latest/meta-data/public-ipv4`
+echo "The public IP for this instance is $public_ip"
+echo "You can bosh target $public_ip, or run vagrant ssh and then bosh target 127.0.0.1"
+  PUBLIC_IP_SCRIPT
+  config.vm.provision :shell, id: "public_ip", run: "always", inline: PUBLIC_IP
+
+  PORT_FORWARDING = <<-IP_SCRIPT
+local_ip=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4`
+echo "Setting up port forwarding for the CF Cloud Controller..."
+sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 80 -j DNAT --to 10.244.0.34:80
+sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 443 -j DNAT --to 10.244.0.34:443
+sudo iptables -t nat -A PREROUTING -p tcp -d $local_ip --dport 4443 -j DNAT --to 10.244.0.34:4443
+  IP_SCRIPT
+  config.vm.provision :shell, id: "port_forwarding", run: "always", inline: PORT_FORWARDING
+end

--- a/templates/vagrant-local.tpl
+++ b/templates/vagrant-local.tpl
@@ -1,0 +1,21 @@
+VM_MEMORY = ENV.fetch('VM_MEMORY', 6*1024).to_i
+VM_CORES = ENV.fetch('VM_CORES', 4).to_i
+
+Vagrant.configure('2') do |config|
+  config.vm.network :private_network, ip: '192.168.50.4'
+  config.vm.hostname='bosh-lite'
+
+  config.vm.provider :virtualbox do |vbox, override|
+    vbox.customize ['modifyvm', :id, '--memory', VM_MEMORY]
+    vbox.customize ['modifyvm', :id, '--cpus', VM_CORES]
+    vbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    vbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+  end
+
+  [:vmware_fusion, :vmware_desktop, :vmware_workstation].each do |provider|
+    config.vm.provider provider do |vmware, override|
+      vmware.vmx["numvcpus"] = VM_CORES
+      vmware.vmx["memsize"] = VM_MEMORY
+    end
+  end
+end

--- a/templates/virtualbox.json
+++ b/templates/virtualbox.json
@@ -4,6 +4,7 @@
   },
   "builders": [{
     "type": "virtualbox-iso",
+    "vm_name": "bosh-lite-ubuntu-trusty",
 
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso",
     "iso_checksum": "4d94f6111b8fe47da94396180ce499d8c0bb44f3",
@@ -62,6 +63,7 @@
     "type": "shell",
     "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
     "scripts": [
+      "scripts/quiet-tty-warning.sh",
       "scripts/update-trusty-kernel.sh",
       "scripts/vbox-guest-additions.sh", 
       "scripts/kernel-cleanup.sh",
@@ -91,6 +93,7 @@
   "post-processors": [{
     "type": "vagrant",
     "keep_input_artifact": true,
+    "vagrantfile_template": "templates/vagrant-local.tpl",
     "output": "bosh-lite-{{ .Provider }}-ubuntu-trusty-{{user `build_number`}}.box"
   }]
 }

--- a/templates/vmware.json
+++ b/templates/vmware.json
@@ -4,6 +4,7 @@
   },
   "builders": [{
     "type": "vmware-iso",
+    "vm_name": "bosh-lite-ubuntu-trusty",
 
     "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso",
     "iso_checksum": "4d94f6111b8fe47da94396180ce499d8c0bb44f3",
@@ -59,6 +60,7 @@
     "type": "shell",
     "execute_command": "echo 'vagrant'|{{.Vars}} sudo -E -S bash '{{.Path}}'",
     "scripts": [
+      "scripts/quiet-tty-warning.sh",
       "scripts/update-trusty-kernel.sh",
       "scripts/vmware-tools.sh",
       "scripts/kernel-cleanup.sh",
@@ -88,6 +90,7 @@
   "post-processors": [{
     "type": "vagrant",
     "keep_input_artifact": true,
+    "vagrantfile_template": "templates/vagrant-local.tpl",
     "output": "bosh-lite-{{ .Provider }}-ubuntu-trusty-{{user `build_number`}}.box"
   }]
 }


### PR DESCRIPTION
This is a proposal for a different way of dealing with provider specific aspects of the bosh-lite vagrant boxes.  Instead of having all of the logic inside of the main `Vagrantfile`, move it into the box file proper.  This greatly simplifies the contents of the main `Vagrantfile` and removes the need for end users to specify a "machine" configuration name.  This style of build is also very well suited for the versioning support and update checks provided by vagrant cloud.

The environment variables that influence the provider config are still honored.  Provisioner scripts in the aws box have been assigned id's so they can be overridden or disabled by the box user.  Configuration that exists in the user's project `Vagrantfile` takes precedence over what's in the box.

I've also made some changes to clean up the messages that are issued when bringing up an aws image and make the aws script provisioners that dump the IP and add routing rules run always.

https://asciinema.org/a/11799 should give an idea of what things look like with these changes.
