### PR TITLE
Add files in tmp/compiled_package_cache folder and old warden stemcell archive to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,11 @@
 manifests/cf-manifest.yml
 bosh_lite_manifest.yml
 
-latest-bosh-stemcell-warden.tgz
+latest-bosh-stemcell-warden.*
 
 /output-virtualbox-iso/
 /output-vmware-iso/
 /packer_cache/
 /pkg/
 /packer-bosh/
+/tmp/compiled_package_cache/*


### PR DESCRIPTION
After running `provision_cf` script I see lots of untracked files in `tmp/compiled_package_cache` folder. is it ok? Also after running `provision_cf` several times I've got latest-bosh-stemcell-warden.tgz.old file untracked. Think they can be added to gitignore.
