### PR TITLE
Pull functions out of provision_cf

### DIFF
--- a/bin/provision_cf
+++ b/bin/provision_cf
@@ -2,66 +2,13 @@
 
 set -xe
 
-STEMCELL_SOURCE=http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/warden
-STEMCELL_FILE=latest-bosh-stemcell-warden.tgz
-WORKSPACE_DIR="$(cd $(dirname ${BASH_SOURCE[0]})/../../ && pwd)"
-BOSH_LITE_DIR="${WORKSPACE_DIR}/bosh-lite"
-CF_DIR="${WORKSPACE_DIR}/cf-release"
+source "$(dirname ${BASH_SOURCE[0]})/provision_cf_funcs"
 
 main() {
   fetch_stemcell
   upload_stemcell
   build_manifest
   deploy_release
-}
-
-fetch_stemcell() {
-  if [[ ! -e $STEMCELL_FILE ]]
-  then
-    curl --progress-bar "${STEMCELL_SOURCE}/${STEMCELL_FILE}" > "$STEMCELL_FILE"
-  fi
-}
-
-upload_stemcell() {
-  ip=$(bosh_lite_ip)
-  bosh -n target $ip
-  bosh -n -u admin -p admin upload stemcell --skip-if-exists $STEMCELL_FILE
-}
-
-build_manifest() {
-  cd $CF_DIR
-  ./update
-
-  cd $BOSH_LITE_DIR
-  export CF_RELEASE_DIR=$CF_DIR
-  ./bin/make_manifest_spiff
-}
-
-deploy_release() {
-  MOST_RECENT_CF_RELEASE=$(find ${CF_DIR}/releases -regex ".*cf-[0-9]*.yml" | sort | tail -n 1)
-  bosh -n -u admin -p admin upload release --skip-if-exists $MOST_RECENT_CF_RELEASE
-  bosh -n -u admin -p admin deploy
-}
-
-get_ip_from_vagrant_ssh_config() {
-  config=$(vagrant ssh-config)
-  ip=$(echo "$config" | grep HostName | awk '{print $2}')
-  echo $ip
-}
-
-get_ip_from_vm_ifconfig() {
-  config=$(vagrant ssh -c ifconfig 2>/dev/null)
-  echo $(echo "$config" | grep addr:192 | awk '{print $2}' | cut -d: -f2)
-}
-
-bosh_lite_ip() {
-  ip=$(get_ip_from_vagrant_ssh_config)
-  # Local VMs show up as 127.0.0.1 in ssh-config so we need to find their IP
-  # elsewhere
-  if [ $ip = "127.0.0.1" ]; then
-    ip=$(get_ip_from_vm_ifconfig)
-  fi
-  echo $ip
 }
 
 main

--- a/bin/provision_cf_funcs
+++ b/bin/provision_cf_funcs
@@ -1,0 +1,54 @@
+STEMCELL_SOURCE=http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/warden
+STEMCELL_FILE=latest-bosh-stemcell-warden.tgz
+WORKSPACE_DIR="$(cd $(dirname ${BASH_SOURCE[0]})/../../ && pwd)"
+BOSH_LITE_DIR="${WORKSPACE_DIR}/bosh-lite"
+CF_DIR="${WORKSPACE_DIR}/cf-release"
+
+fetch_stemcell() {
+  if [[ ! -e $STEMCELL_FILE ]]
+  then
+    curl --progress-bar "${STEMCELL_SOURCE}/${STEMCELL_FILE}" > "$STEMCELL_FILE"
+  fi
+}
+
+upload_stemcell() {
+  ip=$(bosh_lite_ip)
+  bosh -n target $ip
+  bosh -n -u admin -p admin upload stemcell --skip-if-exists $STEMCELL_FILE
+}
+
+build_manifest() {
+  cd $CF_DIR
+  ./update
+
+  cd $BOSH_LITE_DIR
+  export CF_RELEASE_DIR=$CF_DIR
+  ./bin/make_manifest_spiff
+}
+
+deploy_release() {
+  MOST_RECENT_CF_RELEASE=$(find ${CF_DIR}/releases -regex ".*cf-[0-9]*.yml" | sort | tail -n 1)
+  bosh -n -u admin -p admin upload release --skip-if-exists $MOST_RECENT_CF_RELEASE
+  bosh -n -u admin -p admin deploy
+}
+
+get_ip_from_vagrant_ssh_config() {
+  config=$(vagrant ssh-config)
+  ip=$(echo "$config" | grep HostName | awk '{print $2}')
+  echo $ip
+}
+
+get_ip_from_vm_ifconfig() {
+  config=$(vagrant ssh -c ifconfig 2>/dev/null)
+  echo $(echo "$config" | grep addr:192 | awk '{print $2}' | cut -d: -f2)
+}
+
+bosh_lite_ip() {
+  ip=$(get_ip_from_vagrant_ssh_config)
+  # Local VMs show up as 127.0.0.1 in ssh-config so we need to find their IP
+  # elsewhere
+  if [ $ip = "127.0.0.1" ]; then
+    ip=$(get_ip_from_vm_ifconfig)
+  fi
+  echo $ip
+}


### PR DESCRIPTION
This will allow me to source the provision_cf_funcs and use the
functions in another script. For example, I may want to do a slightly
different deploy step, like deploying a development release.