### PR TITLE
Allows BOSH_LITE_PRIVATE_IP to set AWS private ip.

### DIFF
--- a/templates/vagrant-aws.tpl
+++ b/templates/vagrant-aws.tpl
@@ -36,6 +36,7 @@ Vagrant.configure('2') do |config|
     v.security_groups =     [env.fetch('BOSH_LITE_SECURITY_GROUP', 'inception')]
     v.subnet_id =           env.fetch('BOSH_LITE_SUBNET_ID') if env.include?('BOSH_LITE_SUBNET_ID')
     v.tags =                tags_from_environment(env)
+    v.private_ip_address =  env.fetch('BOSH_LITE_PRIVATE_IP') if env.include?('BOSH_LITE_PRIVATE_IP')
   end
 
   meta_data_public_ip_url = "http://169.254.169.254/latest/meta-data/public-ipv4"


### PR DESCRIPTION
The Toolsmiths team would like the ability to assign the private ip address for bosh-lites spun up in our VPC.
