### PR TITLE
Update deploy-cf.md

### DIFF
--- a/docs/deploy-cf.md
+++ b/docs/deploy-cf.md
@@ -9,6 +9,8 @@
     ```
     cd ~/workspace
     git clone https://github.com/cloudfoundry/cf-release
+    cd cf-release
+    ./update
     ```
 
 ### Single command deploy
@@ -73,8 +75,10 @@ $ bosh public stemcells
  `make_manifest_spiff` will target your BOSH Lite Director, find the UUID, create a manifest stub and run spiff to generate a manifest at manifests/cf-manifest.yml. If this fails, try updating Spiff.
 
  ```
- cd ~/workspace/bosh-lite
- ./bin/make_manifest_spiff
+ cd ~/workspace/cf-release
+ git checkout <version>  #version should be same as the release version you uploaded
+ cd ~/workspace/cf-release/bosh-lite
+ ./make_manifest
  ```
 
  If you want to change the jobs properties for this bosh-lite deployment, e.g. number of nats servers, you can change it in the template located under cf-release/templates/cf-infrastructure-warden.yml.


### PR DESCRIPTION
Some steps missed in deploy-cf.md, I added them. Please check if there are correct.

1. run update in cf-release directory to pull all submodules
2. git checkout the cf-release content, version should match the uploaded release version
3. cd to correct directory to run make manifest file
4. there are no bin directory under bosh-lite, run make_manifest_spiff in bosh-lite directory directly