### PR TITLE
Make the aws docs more clear

### DIFF
--- a/docs/aws-provider.md
+++ b/docs/aws-provider.md
@@ -35,6 +35,7 @@ AWS Environment Variables:
 |BOSH_LITE_PRIVATE_KEY          |path to private key matching keypair |~/.ssh/id_rsa_bosh|
 |[VPC only] BOSH_LITE_SUBNET_ID |AWS VPC subnet ID                    | |
 
+* **NOTE**: `BOSH_LITE_SECURITY_GROUP` should be set to group id not the group name, e.g. `sg-11764446`
 * Make sure the EC2 security group you are using in the `Vagrantfile` exists and allows inbound TCP traffic on ports 25555 (for the BOSH director), 22 (for SSH), 80/443 (for Cloud Controller), and 4443 (for Loggregator).
 
 * Run vagrant up with provider `aws`:


### PR DESCRIPTION
I just tried to follow the instructions using the following versions:

```
$ vagrant plugin list
vagrant-aws (0.6.0)
$ vagrant version
Installed Version: 1.7.2
Latest Version: 1.7.2
```

and it failed with this error:
```
There was an error talking to AWS. The error message is shown below:

InvalidParameterCombination => The parameter groupName cannot be used with the parameter subnet
```

Turns out that `BOSH_LITE_SECURITY_GROUP` was set to the security group name instead of the security group id. This pr makes the docs more clear that the group id should be used.