### PR TITLE
Enable allocation of an elastic IP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.provider :aws do |v, override|
     override.vm.box_version = '9000.37.0' # ci:replace
+    v.elastic_ip = true
     # To turn off public IP echoing, uncomment this line:
     # override.vm.provision :shell, id: "public_ip", run: "always", inline: "/bin/true"
 


### PR DESCRIPTION
Without this line in the Vagrantfile, when you run `vagrant up --provider=aws` it won't be able to SSH into the VM because it will only have allocated a private IP address.

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.