### PR TITLE
Enable allocation of an elastic IP

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.provider :aws do |v, override|
     override.vm.box_version = '9000.37.0' # ci:replace
+    v.elastic_ip = true
     # To turn off public IP echoing, uncomment this line:
     # override.vm.provision :shell, id: "public_ip", run: "always", inline: "/bin/true"
 


### PR DESCRIPTION
Hi there!

While doing some testing of bosh-lite on AWS, we noticed that the `vagrant up` step was routinely hanging on SSH, even after we had made sure that the security group had the right rules for allowing connections from the machine doing the provisioning.

It turned out that without the line included in this patch, `vagrant up --provider=aws` was allocating only a private IP address for the VM. In order for the laptop to connect to the host (via SSH or otherwise) it's necessary to additionally allocate an Elastic IP.

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.