### PR TITLE
Remove Ubuntu release upgrader

### DIFF
--- a/scripts/clean-up.sh
+++ b/scripts/clean-up.sh
@@ -2,6 +2,9 @@
 
 set -x
 
+# Remove release upgrader to prevent check-new-release from running
+apt-get remove -y ubuntu-release-upgrader-core
+
 # Make sure Udev doesn't block our network (http://6.ptmc.org/?p=164)
 echo "Cleaning up udev rules"
 rm -rf /etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
When it runs, it can eat up resources in the VM and cause deployments and execution to really slow down.