### PR TITLE
Change cpi provider name from cpi to warden

### DIFF
--- a/templates/bosh_lite_manifest_template.yml
+++ b/templates/bosh_lite_manifest_template.yml
@@ -75,7 +75,7 @@ properties:
     name: "Bosh Lite Director"
     address: 127.0.0.1
     max_tasks: 100
-    cpi_job: cpi
+    cpi_job: warden
     db: *db
 
     # Compatibility with current garden networking manifest config


### PR DESCRIPTION
Some of the community releases automation rely on cpi provider for fetching stemcells.
eg. HAproxy bosh release 

DIRECTOR_CPI required in this : https://github.com/cloudfoundry-community/cf-haproxy-boshrelease/blob/master/templates/make_manifest#L49

is  fetched from bosh status here: 
https://github.com/cloudfoundry-community/cf-haproxy-boshrelease/blob/master/templates/make_manifest#L23