### PR TITLE
Fix paths to scripts moved in cf-release repo

### DIFF
--- a/bin/make_manifest_spiff
+++ b/bin/make_manifest_spiff
@@ -26,7 +26,7 @@ cp $BOSH_LITE_HOME/manifests/cf-stub-spiff.yml $temp_dir/cf-stub-with-uuid.yml
 echo $DIRECTOR_UUID
 perl -pi -e "s/PLACEHOLDER-DIRECTOR-UUID/$DIRECTOR_UUID/g" $temp_dir/cf-stub-with-uuid.yml
 
-$CF_RELEASE_DIR/generate_deployment_manifest \
+$CF_RELEASE_DIR/scripts/generate_deployment_manifest \
 	warden \
 	$temp_dir/cf-stub-with-uuid.yml \
 	$CF_RELEASE_DIR/templates/cf-minimal-dev.yml \

--- a/bin/provision_cf
+++ b/bin/provision_cf
@@ -29,7 +29,7 @@ upload_stemcell() {
 
 build_manifest() {
   cd $CF_DIR
-  ./update
+  ./scripts/update
 
   cd $BOSH_LITE_DIR
   export CF_RELEASE_DIR=$CF_DIR


### PR DESCRIPTION
Whilst trying to provision a CF instance on bosh-lite using the provision_cf script mentioned here: https://github.com/cloudfoundry/bosh-lite we discovered that some scripts were not being found by /bin/provision_cf (update) and /bin/make_manifest_spiff (generate_deployment_manifest).

We can see that there was a commit https://github.com/cloudfoundry/cf-release/commit/1c15bcad196c94bace875893280557895dda906c which moved these scripts out of the top level directory into /scripts.

We made the changes that allowed us to complete the provision of CF on bosh-lite (but no more) and created this pull request. Might be worth searching for other places affected by the cf-release change but we aren't familiar with the codebase.

Signed-off-by: Houssem El Fekih <hfekih@pivotal.io>