### PR TITLE
Fix command line argument passing in provision_cf.

### DIFF
--- a/bin/provision_cf
+++ b/bin/provision_cf
@@ -11,7 +11,7 @@ CF_DIR="${WORKSPACE_DIR}/cf-release"
 main() {
   fetch_stemcell
   upload_stemcell
-  build_manifest
+  build_manifest $@
   deploy_release
 }
 
@@ -61,4 +61,4 @@ bosh_lite_ip() {
   echo $ip
 }
 
-main
+main $@


### PR DESCRIPTION
* Pass args through to build_manifest function to allow customizing deployment manifest.
* build_manifest expected arguments that were not being passed through.

Signed-off-by: Frank Kotsianas <fkotsianas@pivotal.io>