### PR TITLE
Fix for routing-loop issues

### DIFF
--- a/packer/scripts/prevent-routing-loops.sh
+++ b/packer/scripts/prevent-routing-loops.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get install iptables-persistent
+sudo iptables -I FORWARD 1 -p all -o eth0 -d 10.244.0.0/16 -j DROP
+sudo /bin/bash -c "iptables-save > /etc/iptables/rules.v4"

--- a/packer/templates/aws.json
+++ b/packer/templates/aws.json
@@ -28,7 +28,8 @@
       "scripts/kernel-cleanup.sh",
       "scripts/admin-sudoers.sh",
       "scripts/setup-syslog.sh",
-      "scripts/setup-ntpdate.sh"
+      "scripts/setup-ntpdate.sh",
+      "scripts/prevent-routing-loops.sh"
     ]
   },{
     "type": "shell",

--- a/packer/templates/virtualbox.json
+++ b/packer/templates/virtualbox.json
@@ -74,7 +74,8 @@
       "scripts/admin-sudoers.sh",
       "scripts/increase-loop-devices.sh",
       "scripts/setup-syslog.sh",
-      "scripts/setup-ntpdate.sh"
+      "scripts/setup-ntpdate.sh",
+      "scripts/prevent-routing-loops.sh"
     ]
   },{
     "type": "shell",

--- a/packer/templates/vmware.json
+++ b/packer/templates/vmware.json
@@ -73,7 +73,8 @@
       "scripts/admin-sudoers.sh",
       "scripts/increase-loop-devices.sh",
       "scripts/setup-syslog.sh",
-      "scripts/setup-ntpdate.sh"
+      "scripts/setup-ntpdate.sh",
+      "scripts/prevent-routing-loops.sh"
     ]
   },{
     "type": "shell",


### PR DESCRIPTION
Added an iptables rule to block all forwarded traffic from going out
eth0 with a destination of 10.244.0.0/16. This prevents routing loops
from occurring when IPs do not exist on local warden/garden container
interfaces, but the host machine has a route forwarding 10.244.0.0/16
to the vagrant VM.

Fixes #318