### PR TITLE
Clarify `Deploy Cloud Foundry` ambiguous instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The local VMs (virtualbox, vmware providers) will be accessible at `192.168.50.4
 
 ## Deploy Cloud Foundry
 
-See [deploying Cloud Foundry documentation](http://docs.cloudfoundry.org/deploying/boshlite/deploy_cf_boshlite.html) for detailed instructions. Alternatively, check out [CF Release](https://github.com/cloudfoundry/cf-release) as `~/workspace/cf-release` and run `./bin/provision_cf` from this repository.
+See [deploying Cloud Foundry documentation](http://docs.cloudfoundry.org/deploying/boshlite/deploy_cf_boshlite.html) for detailed instructions. Alternatively, check out [CF Release](https://github.com/cloudfoundry/cf-release) as `~/workspace/cf-release` and return to the `bosh-lite` repository and run `./bin/provision_cf`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Make instructions about deploying cloud foundry more explicit