### PR TITLE
Revert "Update resolv.conf to use 8.8.8.8"

### DIFF
--- a/packer/scripts/update-resolv.conf.sh
+++ b/packer/scripts/update-resolv.conf.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-echo 'nameserver 8.8.8.8' >> /etc/resolvconf/resolv.conf.d/head
-resolvconf -u

--- a/packer/templates/virtualbox.json
+++ b/packer/templates/virtualbox.json
@@ -64,7 +64,6 @@
     "type": "shell",
     "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
     "scripts": [
-      "scripts/update-resolv.conf.sh",
       "scripts/quiet-tty-warning.sh",
       "scripts/apt-update.sh",
       "scripts/update-ruby.sh",

--- a/packer/templates/vmware.json
+++ b/packer/templates/vmware.json
@@ -63,7 +63,6 @@
     "type": "shell",
     "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
     "scripts": [
-      "scripts/update-resolv.conf.sh",
       "scripts/quiet-tty-warning.sh",
       "scripts/apt-update.sh",
       "scripts/update-ruby.sh",


### PR DESCRIPTION
DNS configuration should not be hard-coded. This causes issues for those who have external DNS blocked for any reasons. Blocking external DNS is very common for private networks.