### PR TITLE
Warn users: Fusion = no go

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Installation instructions for different Vagrant providers:
 * VirtualBox (below)
 * [AWS](docs/aws-provider.md)
 
+**VMWare Fusion is unsupported.** If you attempt `vagrant up --provider=vmware_fusion` you'll receive
+an error message stating that Fusion is unsupported and that the image cannot be found. For this reason,
+[VirtualBox](https://virtualbox.org) is strongly suggested.
+
 #### Using the VirtualBox Provider
 
 1. Make sure your machine has at least 8GB RAM, and 100GB free disk space. Smaller configurations may work.


### PR DESCRIPTION
I was (mistakenly) under the impression that, "oh hey, no big deal I can just `vagrant up` this thing with Fusion as the provider!" Yeeeah...I learned that was a Bad Idea(TM):

```
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Box 'cloudfoundry/no-support-for-bosh-lite-on-fusion' could not be found. Attempting to find and install...
    default: Box Provider: vmware_desktop, vmware_fusion, vmware_workstation
    default: Box Version: >= 0
The box 'cloudfoundry/no-support-for-bosh-lite-on-fusion' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/cloudfoundry/no-support-for-bosh-lite-on-fusion"]
Error: The requested URL returned error: 404 Not Found
```

This PR updates the readme with a short bolded sentence (to catch the eye of your average casual skimmer, hopefully) explaining that Fusion is unsupported and to use VirtualBox instead.