### PR TITLE
 Make gateway configurable via arg in add-route script

### DIFF
--- a/bin/add-route
+++ b/bin/add-route
@@ -1,24 +1,22 @@
-#!/bin/bash
-
-set -x
+#!/bin/bash -ex
 
 old_ips="10.244.0.0/19"
 ips="10.244.0.0/16"
-gw="192.168.50.4"
+gw="${1:-"192.168.50.4"}"
 
 echo "Adding the following route entry to your local route table to enable direct container access: $ips via $gw. Your sudo password may be required." > /dev/null
 
-if [ `uname` = "Darwin" ]; then
-  sudo route delete -net $old_ips $gw
-  sudo route delete -net $ips     $gw
-  sudo route add    -net $ips     $gw
-elif [ `uname` = "Linux" ]; then
+if [ "$(uname)" = "Darwin" ]; then
+  sudo route delete -net "$old_ips" "$gw"
+  sudo route delete -net "$ips"     "$gw"
+  sudo route add    -net "$ips"     "$gw"
+elif [ "$(uname)" = "Linux" ]; then
   if type route > /dev/null 2>&1; then
-    sudo route del -net $old_ips gw $gw
-    sudo route add -net $ips     gw $gw
+    sudo route del -net "$old_ips" gw "$gw"
+    sudo route add -net "$ips"     gw "$gw"
   elif type ip > /dev/null 2>&1; then
-    sudo ip route del $old_ips via $gw
-    sudo ip route add $ips     via $gw
+    sudo ip route del "$old_ips" via "$gw"
+    sudo ip route add "$ips"     via "$gw"
   else
     echo "ERROR adding route"
     exit 1


### PR DESCRIPTION
I've just created an AWS bosh-lite. I needed to run this script for an AWS EIP. Being able to overwrite the default gateway IP via an argument worked well.

I couldn't help fixing all shellcheck violations.