### PR TITLE
Add Route before Cloudcheck

### DIFF
--- a/docs/bosh-cck.md
+++ b/docs/bosh-cck.md
@@ -2,6 +2,8 @@
 
 The Warden container will be lost after a VM reboot, but you can restore your deployment with `bosh cck`, BOSH's command for recovering from unexpected errors. Alternatively *Pause* the VM from the VirtualBox UI (or `vagrant suspend`) before shutting down, or making your computer sleep.
 
+Note: the network routes may also need to be restored.  To do this run the `./bin/add-route` script before starting the `bosh cck`.
+
 ```
 $ bosh cck
 ```


### PR DESCRIPTION
It is useful to run `./bin/add-route` before running `bosh cck` because usually the same reason that's causing the Warden container to be down is that the host has been powered off, or the virtual machine had not been saved/suspended before turning it off.