### PR TITLE
Set workers to 11 and enable_dedicated_status_worker

### DIFF
--- a/packer/templates/bosh_lite_manifest_template.yml
+++ b/packer/templates/bosh_lite_manifest_template.yml
@@ -73,6 +73,8 @@ properties:
     db: *db
     flush_arp: true
     enable_post_deploy: true
+    enable_dedicated_status_worker: true
+    workers: 11
     events:
       record_events: true
 


### PR DESCRIPTION
The default worker count is really low for teams who want to run multiple bosh deployments in parallel.