### PR TITLE
Add br-netfilter module to bosh-lite host

### DIFF
--- a/packer/scripts/add-br-netfilter-module.sh
+++ b/packer/scripts/add-br-netfilter-module.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+echo br_netfilter >> /etc/modules

--- a/packer/templates/aws.json
+++ b/packer/templates/aws.json
@@ -27,6 +27,7 @@
       "scripts/update-trusty-kernel.sh",
       "scripts/kernel-cleanup.sh",
       "scripts/admin-sudoers.sh",
+      "scripts/add-br-netfilter-module.sh",
       "scripts/setup-syslog.sh",
       "scripts/setup-ntpdate.sh",
       "scripts/prevent-routing-loops.sh",

--- a/packer/templates/virtualbox.json
+++ b/packer/templates/virtualbox.json
@@ -72,6 +72,7 @@
       "scripts/vbox-guest-additions.sh",
       "scripts/kernel-cleanup.sh",
       "scripts/admin-sudoers.sh",
+      "scripts/add-br-netfilter-module.sh",
       "scripts/increase-loop-devices.sh",
       "scripts/setup-syslog.sh",
       "scripts/setup-ntpdate.sh",

--- a/packer/templates/vmware.json
+++ b/packer/templates/vmware.json
@@ -71,6 +71,7 @@
       "scripts/vmware-tools.sh",
       "scripts/kernel-cleanup.sh",
       "scripts/admin-sudoers.sh",
+      "scripts/add-br-netfilter-module.sh",
       "scripts/increase-loop-devices.sh",
       "scripts/setup-syslog.sh",
       "scripts/setup-ntpdate.sh",


### PR DESCRIPTION
When applying iptables to linux bridges, the br_netfilter module is often needed. Given garden uses bridges by default, it would be great if the module was loaded on the host by default.
