### PR TITLE
Ubuntu 14.04.5 with xenial backport for kernel 4.4

### DIFF
--- a/packer/scripts/kernel-cleanup.sh
+++ b/packer/scripts/kernel-cleanup.sh
@@ -7,10 +7,10 @@ export DEBIAN_FRONTEND=noninteractive
 echo "Removing kernels that do not match $(uname -r)"
 
 # delete stale linux kernels
-dpkg --list | awk '{ print $2 }' | grep 'linux-image-3.*' | grep -vF "$(uname -r)" | xargs apt-get -y purge
+dpkg --list | awk '{ print $2 }' | grep 'linux-image-[34].*' | grep -vF "$(uname -r)" | xargs apt-get -y purge
 
 # delete stale linux headers
-dpkg --list | awk '{ print $2 }' | grep 'linux-headers-3.*' | grep -vF "$(uname -r)" | xargs apt-get -y purge
+dpkg --list | awk '{ print $2 }' | grep 'linux-headers-[34].*' | grep -vF "$(uname -r)" | xargs apt-get -y purge
 
 # delete linux source
 dpkg --list | awk '{ print $2 }' | grep linux-source | xargs apt-get -y purge

--- a/packer/scripts/update-trusty-kernel.sh
+++ b/packer/scripts/update-trusty-kernel.sh
@@ -5,7 +5,7 @@ set -ex
 export UCF_FORCE_CONFFNEW=YES
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get -y --force-yes install linux-generic-lts-vivid
+apt-get -y --force-yes install linux-generic-lts-xenial
 
 reboot
 sleep 60

--- a/packer/templates/virtualbox.json
+++ b/packer/templates/virtualbox.json
@@ -5,8 +5,8 @@
   "builders": [{
     "type": "virtualbox-iso",
 
-    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso",
-    "iso_checksum": "3ffb7a3690ce9a07ac4a4d1b829f990681f7e47d",
+    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso",
+    "iso_checksum": "5e567024c385cc8f90c83d6763c6e4f1cd5deb6f",
     "iso_checksum_type": "sha1",
 
     "guest_os_type": "Ubuntu_64",

--- a/packer/templates/vmware.json
+++ b/packer/templates/vmware.json
@@ -5,8 +5,8 @@
   "builders": [{
     "type": "vmware-iso",
 
-    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
-    "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
+    "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso",
+    "iso_checksum": "5e567024c385cc8f90c83d6763c6e4f1cd5deb6f",
     "iso_checksum_type": "sha1",
 
     "guest_os_type": "ubuntu-64",


### PR DESCRIPTION
Upgrade the kernel in bosh-lite to 4.4.

Unable to test the AWS configuration but it looks like the correct base AMI might be `ami-a15e0db6`.
