### PR TITLE
Support BOSH_AWS_REGION environment variable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure('2') do |config|
     # (Must not fail due to missing ENV variables because this file is loaded for all providers)
     v.access_key_id = ENV['BOSH_AWS_ACCESS_KEY_ID'] || ''
     v.secret_access_key = ENV['BOSH_AWS_SECRET_ACCESS_KEY'] || ''
+    v.region = ENV['BOSH_AWS_REGION'] || 'us-east-1'
     v.ami = ''
   end
 


### PR DESCRIPTION
I like to run my bosh-lite in us-west-1