### PR TITLE
Mention dependency of manifest generation on jq utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CA certificate that can be used with the BOSH CLI is saved in `ca/certs/ca.crt`.
 
 ## Deploy Cloud Foundry
 
-See [deploying Cloud Foundry documentation](http://docs.cloudfoundry.org/deploying/boshlite/deploy_cf_boshlite.html) for detailed instructions. Alternatively, check out [CF Release](https://github.com/cloudfoundry/cf-release) as `~/workspace/cf-release` and return to the `bosh-lite` repository and run `./bin/provision_cf`.
+See [deploying Cloud Foundry documentation](http://docs.cloudfoundry.org/deploying/boshlite/deploy_cf_boshlite.html) for detailed instructions. Alternatively, check out [CF Release](https://github.com/cloudfoundry/cf-release) as `~/workspace/cf-release` and return to the `bosh-lite` repository and run `./bin/provision_cf`. This script has a local dependency on the [jq](https://github.com/stedolan/jq) utility.
 
 ## Troubleshooting
 


### PR DESCRIPTION
A change in documentation subsequent to this change https://github.com/cloudfoundry/cf-release/pull/1108

This change to manifest generation was necessary to make the generated manifest work out-of-the-box after a security change in UAA.

The `jq` utility was necessary to construct some JSON and reliably escape the key and cert for merging into the YML.