### PR TITLE
Allow define the AWS_SESSION_TOKEN to use

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure('2') do |config|
     # (Must not fail due to missing ENV variables because this file is loaded for all providers)
     v.access_key_id = ENV['BOSH_AWS_ACCESS_KEY_ID'] || ''
     v.secret_access_key = ENV['BOSH_AWS_SECRET_ACCESS_KEY'] || ''
+    v.session_token = ENV['BOSH_AWS_SESSION_TOKEN'] || ''
     v.ami = ''
   end
 

--- a/docs/aws-provider.md
+++ b/docs/aws-provider.md
@@ -44,6 +44,7 @@ The full list of supported environment variables follows:
 |---|---|---|
 |BOSH_AWS_ACCESS_KEY_ID     |AWS Access Key ID                    | |
 |BOSH_AWS_SECRET_ACCESS_KEY |AWS Secret Access Key                | |
+|BOSH_AWS_SESSION_TOKEN     |AWS STS Session Token                | |
 |BOSH_LITE_REGION           |AWS Region name                      |us-east-1|
 |BOSH_LITE_KEYPAIR          |AWS EC2 Key Pair name                |bosh|
 |BOSH_LITE_PRIVATE_KEY      |Local file path for private key matching `BOSH_LITE_KEYPAIR` |~/.ssh/id_rsa_bosh|


### PR DESCRIPTION
If you want to use temporary STS credentials[1], you must also pass the
AWS session token.

This commit allows define the variable $BOSH_AWS_SESSION_TOKEN to define it.

[1] http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html