### PR TITLE
Add downloaded bosh lite stemcell to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 manifests/cf-manifest.yml
 bosh_lite_manifest.yml
 
-latest-bosh-stemcell-warden.*
+latest-bosh*-stemcell-warden.*
 bosh-stemcell-*-warden-*
 
 /tmp/compiled_package_cache/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,13 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'cloudfoundry/bosh-lite'
 
   config.vm.provider :virtualbox do |v, override|
-    override.vm.box_version = '9000.131.0' # ci:replace
+    override.vm.box_version = '9000.137.0' # ci:replace
     # To use a different IP address for the bosh-lite director, uncomment this line:
     # override.vm.network :private_network, ip: '192.168.59.4', id: :local
   end
 
   config.vm.provider :aws do |v, override|
-    override.vm.box_version = '9000.131.0' # ci:replace
+    override.vm.box_version = '9000.137.0' # ci:replace
     # To turn off public IP echoing, uncomment this line:
     # override.vm.provision :shell, id: "public_ip", run: "always", inline: "/bin/true"
 


### PR DESCRIPTION
The process of installing a bosh-lite + cf requires a bosh-lite stemcell to be downloaded. At the end of the process, my local git repository reported some changes:

```bash
± dlr |master ?:1 ✗| → git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        latest-bosh-lite-stemcell-warden.tgz

nothing added to commit but untracked files present (use "git add" to track)
```

This PR adds the downloaded *latest-bosh-lite-stemcell-warden.tgz* to gitignore.